### PR TITLE
Bump brain 0.1.17

### DIFF
--- a/brain/Dockerfile
+++ b/brain/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/dappnode/staking-brain:0.1.14
+FROM ghcr.io/dappnode/staking-brain:0.1.17
 ENV NETWORK=holesky

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -29,7 +29,10 @@
   },
   "license": "Apache-2.0",
   "requirements": {
-    "minimumDappnodeVersion": "0.2.83"
+    "minimumDappnodeVersion": "0.2.89"
+  },
+  "optionalDependencies": {
+    "prysm-holesky.dnp.dappnode.eth": "0.1.2"
   },
   "globalEnvs": [
     {


### PR DESCRIPTION
Bump brain to `v0.1.17` to match new auth-token for Prysm validator