### PR TITLE
Bump brain 0.1.18

### DIFF
--- a/brain/Dockerfile
+++ b/brain/Dockerfile
@@ -1,2 +1,2 @@
-FROM ghcr.io/dappnode/staking-brain:0.1.17
+FROM ghcr.io/dappnode/staking-brain:0.1.18
 ENV NETWORK=holesky


### PR DESCRIPTION
Bump brain to `v0.1.18`

This will allow GET requests to the `/eth/v1/keystores` endpoint, retrieving the keystores from the web3signer (it actually proxies the request to the signer as the `getValidators` call to the brain does not follow the same format as the web3signer response)